### PR TITLE
Fix for incorrect csfalconid #1

### DIFF
--- a/install-csf.sh
+++ b/install-csf.sh
@@ -11,6 +11,7 @@ then
 	# Client ID, Client Secret for the API token. Then make a base64 version.
 	clientid=""
 	secret=""
+	customerid=""
 	b64creds=$( printf "$clientid:$secret" | /usr/bin/iconv -t ISO-8859-1 | /usr/bin/base64 -i - )
 
 	# Set a default URL
@@ -61,6 +62,7 @@ then
 
 	# Finally install and clean up
 	/usr/sbin/installer -target / -pkg /private/tmp/${sensorname}
+	/Applications/Falcon.app/Contents/Resources/falconctl license $customerid
 	/bin/rm /private/tmp/${sensorname}
 else
 	echo "Crowdstrike already present."

--- a/uninstall-csf.sh
+++ b/uninstall-csf.sh
@@ -27,8 +27,8 @@ then
 
     # Work out Client ID from current install
     # Remove all - characters otherwise CS API shows erroneous results.
-    csfalconstats=$( /Applications/Falcon.app/Contents/Resources/falconctl stats )
-    csfalconid=$( echo $csfalconstats | /usr/bin/grep "agentID:" | /usr/bin/awk '{ print $2 }' | /usr/bin/tr -d "-" )
+    csfalconstats=$( /Applications/Falcon.app/Contents/Resources/falconctl stats | /usr/bin/grep "agentID:" )
+    csfalconid=$( echo $csfalconstats | /usr/bin/awk '{ print $2 }' | /usr/bin/tr -d "-" )
 
     # Request bearer access token using the API
     token=$( /usr/bin/curl -s -X POST "$oauthtoken" -H "accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=${clientid}&client_secret=${secret}" )


### PR DESCRIPTION
This should resolve #1 and also adds a CustomerID to automatically load the license immediately after installation.